### PR TITLE
pslab device scan implemented

### DIFF
--- a/src/hardware/pslab/api.c
+++ b/src/hardware/pslab/api.c
@@ -32,13 +32,12 @@ static const struct analog_channel analog_channels[] = {
 		{"VOL", 8},
 };
 
-
 static struct sr_dev_driver pslab_driver_info;
 
 static GSList *scan(struct sr_dev_driver *di, GSList *options)
 {
-	(void) options;
 	GSList *l, *devices;
+	struct sr_config *src;
 
 	GSList *device_paths_v5 = sr_serial_find_usb(0x04D8, 0x00DF);
 
@@ -50,9 +49,32 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 	struct sr_serial_dev_inst *serial;
 	struct sr_dev_inst *sdi;
 
+	const char *path = NULL;
+	const char *serialcomm = "1000000/8n1";
+
+	for (l = options; l; l = l->next)
+	{
+		src = l->data;
+		switch (src->key) {
+			case SR_CONF_CONN:
+				path = g_variant_get_string(src->data, NULL);
+				break;
+			case SR_CONF_SERIALCOMM:
+				serialcomm = g_variant_get_string(src->data, NULL);
+				break;
+		}
+	}
+
 	for (l = device_paths; l; l = l->next)
 	{
-		serial = sr_serial_dev_inst_new(l->data, NULL);
+		if (path && path != l->data) {
+			continue;
+		}
+		serial = sr_serial_dev_inst_new(l->data, serialcomm);
+
+		if (serial_open(serial, SERIAL_RDWR) != SR_OK) {
+			continue;
+		}
 
 		sdi = g_new0(struct sr_dev_inst, 1);
 		sdi->status = SR_ST_INACTIVE;
@@ -85,6 +107,7 @@ static GSList *scan(struct sr_dev_driver *di, GSList *options)
 		}
 		sdi->channel_groups = g_slist_append(NULL, cg);
 		devices = g_slist_append(devices, sdi);
+		serial_close(serial);
 	}
 	return std_scan_complete(di, devices);
 }

--- a/src/hardware/pslab/api.c
+++ b/src/hardware/pslab/api.c
@@ -18,117 +18,155 @@
  */
 
 #include <config.h>
+#include <math.h>
 #include "protocol.h"
+
+static const struct analog_channel analog_channels[] = {
+        {"CH1", 3},
+        {"CH2", 0},
+        {"CH3", 1},
+        {"MIC", 2},
+        {"AN4", 4},
+        {"RES", 7},
+        {"CAP", 5},
+        {"VOL", 8},
+};
+
 
 static struct sr_dev_driver pslab_driver_info;
 
-static GSList *scan(struct sr_dev_driver *di, GSList *options)
-{
-	struct drv_context *drvc;
-	GSList *devices;
+static GSList *scan(struct sr_dev_driver *di, GSList *options) {
+    (void) options;
+    GSList *l, *devices;
 
-	(void)options;
+    GSList *device_paths_v5 = sr_serial_find_usb(0x04D8, 0x00DF);
 
-	devices = NULL;
-	drvc = di->context;
-	drvc->instances = NULL;
+    GSList *device_paths_v6 = sr_serial_find_usb(0x10C4, 0xEA60);
 
-	/* TODO: scan for devices, either based on a SR_CONF_CONN option
-	 * or on a USB scan. */
+    GSList *device_paths = g_slist_concat(device_paths_v5, device_paths_v6);
 
-	return devices;
+    devices = NULL;
+    struct sr_serial_dev_inst *serial;
+    struct sr_dev_inst *sdi;
+
+    for (l = device_paths; l; l = l->next) {
+
+        serial = sr_serial_dev_inst_new(l->data, NULL);
+
+        sdi = g_new0(struct sr_dev_inst, 1);
+        sdi->status = SR_ST_INACTIVE;
+        sdi->inst_type = SR_INST_SERIAL;
+        sdi->vendor = g_strdup("PSLab");
+        sdi->connection_id = l->data; // make a unique conn id to identify devices -- eg. port_name
+        sdi->conn = serial;
+
+        struct sr_channel_group *cg = g_new0(struct sr_channel_group, 1);
+        cg->name = g_strdup("Analog");
+        cg->channels = g_slist_alloc();
+        for (int i = 0; i < NUM_ANALOG_CHANNELS; i++) {
+            struct sr_channel *ch = sr_channel_new(sdi, i, SR_CHANNEL_ANALOG, TRUE, analog_channels[i].name);
+            struct channel_priv *cp = g_new0(struct channel_priv, 1);
+            cp->chosa = analog_channels[i].chosa;
+            cp->gain = 1;
+            cp->resolution = pow(2, 10) - 1;
+            if (!g_strcmp0(analog_channels[i].name, "CH1")) {
+                cp->programmable_gain_amplifier = 1;
+            } else if (!g_strcmp0(analog_channels[i].name, "CH2")) {
+                cp->programmable_gain_amplifier = 2;
+            }
+
+            ch->priv = cp;
+            cg->channels = g_slist_append(cg->channels, ch);
+        }
+        sdi->channel_groups = g_slist_append(NULL, cg);
+        devices = g_slist_append(devices, sdi);
+    }
+    return std_scan_complete(di, devices);
 }
 
-static int dev_open(struct sr_dev_inst *sdi)
-{
-	(void)sdi;
+static int dev_open(struct sr_dev_inst *sdi) {
+    (void) sdi;
 
-	/* TODO: get handle from sdi->conn and open it. */
+    /* TODO: get handle from sdi->conn and open it. */
 
-	return SR_OK;
+    return SR_OK;
 }
 
-static int dev_close(struct sr_dev_inst *sdi)
-{
-	(void)sdi;
+static int dev_close(struct sr_dev_inst *sdi) {
+    (void) sdi;
 
-	/* TODO: get handle from sdi->conn and close it. */
+    /* TODO: get handle from sdi->conn and close it. */
 
-	return SR_OK;
+    return SR_OK;
 }
 
 static int config_get(uint32_t key, GVariant **data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
-{
-	int ret;
+                      const struct sr_dev_inst *sdi, const struct sr_channel_group *cg) {
+    int ret;
 
-	(void)sdi;
-	(void)data;
-	(void)cg;
+    (void) sdi;
+    (void) data;
+    (void) cg;
 
-	ret = SR_OK;
-	switch (key) {
-	/* TODO */
-	default:
-		return SR_ERR_NA;
-	}
+    ret = SR_OK;
+    switch (key) {
+        /* TODO */
+        default:
+            return SR_ERR_NA;
+    }
 
-	return ret;
+    return ret;
 }
 
 static int config_set(uint32_t key, GVariant *data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
-{
-	int ret;
+                      const struct sr_dev_inst *sdi, const struct sr_channel_group *cg) {
+    int ret;
 
-	(void)sdi;
-	(void)data;
-	(void)cg;
+    (void) sdi;
+    (void) data;
+    (void) cg;
 
-	ret = SR_OK;
-	switch (key) {
-	/* TODO */
-	default:
-		ret = SR_ERR_NA;
-	}
+    ret = SR_OK;
+    switch (key) {
+        /* TODO */
+        default:
+            ret = SR_ERR_NA;
+    }
 
-	return ret;
+    return ret;
 }
 
 static int config_list(uint32_t key, GVariant **data,
-	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
-{
-	int ret;
+                       const struct sr_dev_inst *sdi, const struct sr_channel_group *cg) {
+    int ret;
 
-	(void)sdi;
-	(void)data;
-	(void)cg;
+    (void) sdi;
+    (void) data;
+    (void) cg;
 
-	ret = SR_OK;
-	switch (key) {
-	/* TODO */
-	default:
-		return SR_ERR_NA;
-	}
+    ret = SR_OK;
+    switch (key) {
+        /* TODO */
+        default:
+            return SR_ERR_NA;
+    }
 
-	return ret;
+    return ret;
 }
 
-static int dev_acquisition_start(const struct sr_dev_inst *sdi)
-{
-	/* TODO: configure hardware, reset acquisition state, set up
-	 * callbacks and send header packet. */
+static int dev_acquisition_start(const struct sr_dev_inst *sdi) {
+    /* TODO: configure hardware, reset acquisition state, set up
+     * callbacks and send header packet. */
 
-	(void)sdi;
+    (void) sdi;
 
-	return SR_OK;
+    return SR_OK;
 }
 
-static int dev_acquisition_stop(struct sr_dev_inst *sdi)
-{
-	/* TODO: stop acquisition. */
+static int dev_acquisition_stop(struct sr_dev_inst *sdi) {
+    /* TODO: stop acquisition. */
 
-	(void)sdi;
+    (void) sdi;
 
 	return SR_OK;
 }

--- a/src/hardware/pslab/api.c
+++ b/src/hardware/pslab/api.c
@@ -22,151 +22,163 @@
 #include "protocol.h"
 
 static const struct analog_channel analog_channels[] = {
-        {"CH1", 3},
-        {"CH2", 0},
-        {"CH3", 1},
-        {"MIC", 2},
-        {"AN4", 4},
-        {"RES", 7},
-        {"CAP", 5},
-        {"VOL", 8},
+		{"CH1", 3},
+		{"CH2", 0},
+		{"CH3", 1},
+		{"MIC", 2},
+		{"AN4", 4},
+		{"RES", 7},
+		{"CAP", 5},
+		{"VOL", 8},
 };
 
 
 static struct sr_dev_driver pslab_driver_info;
 
-static GSList *scan(struct sr_dev_driver *di, GSList *options) {
-    (void) options;
-    GSList *l, *devices;
+static GSList *scan(struct sr_dev_driver *di, GSList *options)
+{
+	(void) options;
+	GSList *l, *devices;
 
-    GSList *device_paths_v5 = sr_serial_find_usb(0x04D8, 0x00DF);
+	GSList *device_paths_v5 = sr_serial_find_usb(0x04D8, 0x00DF);
 
-    GSList *device_paths_v6 = sr_serial_find_usb(0x10C4, 0xEA60);
+	GSList *device_paths_v6 = sr_serial_find_usb(0x10C4, 0xEA60);
 
-    GSList *device_paths = g_slist_concat(device_paths_v5, device_paths_v6);
+	GSList *device_paths = g_slist_concat(device_paths_v5, device_paths_v6);
 
-    devices = NULL;
-    struct sr_serial_dev_inst *serial;
-    struct sr_dev_inst *sdi;
+	devices = NULL;
+	struct sr_serial_dev_inst *serial;
+	struct sr_dev_inst *sdi;
 
-    for (l = device_paths; l; l = l->next) {
+	for (l = device_paths; l; l = l->next)
+	{
+		serial = sr_serial_dev_inst_new(l->data, NULL);
 
-        serial = sr_serial_dev_inst_new(l->data, NULL);
+		sdi = g_new0(struct sr_dev_inst, 1);
+		sdi->status = SR_ST_INACTIVE;
+		sdi->inst_type = SR_INST_SERIAL;
+		sdi->vendor = g_strdup("FOSSASIA");
+		sdi->connection_id = l->data;
+		sdi->conn = serial;
 
-        sdi = g_new0(struct sr_dev_inst, 1);
-        sdi->status = SR_ST_INACTIVE;
-        sdi->inst_type = SR_INST_SERIAL;
-        sdi->vendor = g_strdup("PSLab");
-        sdi->connection_id = l->data; // make a unique conn id to identify devices -- eg. port_name
-        sdi->conn = serial;
+		struct sr_channel_group *cg = g_new0(struct sr_channel_group, 1);
+		cg->name = g_strdup("Analog");
+		cg->channels = g_slist_alloc();
+		for (int i = 0; i < NUM_ANALOG_CHANNELS; i++)
+		{
+			struct sr_channel *ch = sr_channel_new(sdi, i, SR_CHANNEL_ANALOG, TRUE, analog_channels[i].name);
+			struct channel_priv *cp = g_new0(struct channel_priv, 1);
+			cp->chosa = analog_channels[i].chosa;
+			cp->gain = 1;
+			cp->resolution = pow(2, 10) - 1;
+			if (!g_strcmp0(analog_channels[i].name, "CH1"))
+			{
+				cp->programmable_gain_amplifier = 1;
+			}
+			else if (!g_strcmp0(analog_channels[i].name, "CH2"))
+			{
+				cp->programmable_gain_amplifier = 2;
+			}
 
-        struct sr_channel_group *cg = g_new0(struct sr_channel_group, 1);
-        cg->name = g_strdup("Analog");
-        cg->channels = g_slist_alloc();
-        for (int i = 0; i < NUM_ANALOG_CHANNELS; i++) {
-            struct sr_channel *ch = sr_channel_new(sdi, i, SR_CHANNEL_ANALOG, TRUE, analog_channels[i].name);
-            struct channel_priv *cp = g_new0(struct channel_priv, 1);
-            cp->chosa = analog_channels[i].chosa;
-            cp->gain = 1;
-            cp->resolution = pow(2, 10) - 1;
-            if (!g_strcmp0(analog_channels[i].name, "CH1")) {
-                cp->programmable_gain_amplifier = 1;
-            } else if (!g_strcmp0(analog_channels[i].name, "CH2")) {
-                cp->programmable_gain_amplifier = 2;
-            }
-
-            ch->priv = cp;
-            cg->channels = g_slist_append(cg->channels, ch);
-        }
-        sdi->channel_groups = g_slist_append(NULL, cg);
-        devices = g_slist_append(devices, sdi);
-    }
-    return std_scan_complete(di, devices);
+			ch->priv = cp;
+			cg->channels = g_slist_append(cg->channels, ch);
+		}
+		sdi->channel_groups = g_slist_append(NULL, cg);
+		devices = g_slist_append(devices, sdi);
+	}
+	return std_scan_complete(di, devices);
 }
 
-static int dev_open(struct sr_dev_inst *sdi) {
-    (void) sdi;
+static int dev_open(struct sr_dev_inst *sdi)
+{
+	(void)sdi;
 
-    /* TODO: get handle from sdi->conn and open it. */
+	/* TODO: get handle from sdi->conn and open it. */
 
-    return SR_OK;
+	return SR_OK;
 }
 
-static int dev_close(struct sr_dev_inst *sdi) {
-    (void) sdi;
+static int dev_close(struct sr_dev_inst *sdi)
+{
+	(void)sdi;
 
-    /* TODO: get handle from sdi->conn and close it. */
+	/* TODO: get handle from sdi->conn and close it. */
 
-    return SR_OK;
+	return SR_OK;
 }
 
 static int config_get(uint32_t key, GVariant **data,
-                      const struct sr_dev_inst *sdi, const struct sr_channel_group *cg) {
-    int ret;
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
 
-    (void) sdi;
-    (void) data;
-    (void) cg;
+	(void)sdi;
+	(void)data;
+	(void)cg;
 
-    ret = SR_OK;
-    switch (key) {
-        /* TODO */
-        default:
-            return SR_ERR_NA;
-    }
+	ret = SR_OK;
+	switch (key) {
+	/* TODO */
+	default:
+		return SR_ERR_NA;
+	}
 
-    return ret;
+	return ret;
 }
 
 static int config_set(uint32_t key, GVariant *data,
-                      const struct sr_dev_inst *sdi, const struct sr_channel_group *cg) {
-    int ret;
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
 
-    (void) sdi;
-    (void) data;
-    (void) cg;
+	(void)sdi;
+	(void)data;
+	(void)cg;
 
-    ret = SR_OK;
-    switch (key) {
-        /* TODO */
-        default:
-            ret = SR_ERR_NA;
-    }
+	ret = SR_OK;
+	switch (key) {
+	/* TODO */
+	default:
+		ret = SR_ERR_NA;
+	}
 
-    return ret;
+	return ret;
 }
 
 static int config_list(uint32_t key, GVariant **data,
-                       const struct sr_dev_inst *sdi, const struct sr_channel_group *cg) {
-    int ret;
+	const struct sr_dev_inst *sdi, const struct sr_channel_group *cg)
+{
+	int ret;
 
-    (void) sdi;
-    (void) data;
-    (void) cg;
+	(void)sdi;
+	(void)data;
+	(void)cg;
 
-    ret = SR_OK;
-    switch (key) {
-        /* TODO */
-        default:
-            return SR_ERR_NA;
-    }
+	ret = SR_OK;
+	switch (key) {
+	/* TODO */
+	default:
+		return SR_ERR_NA;
+	}
 
-    return ret;
+	return ret;
 }
 
-static int dev_acquisition_start(const struct sr_dev_inst *sdi) {
-    /* TODO: configure hardware, reset acquisition state, set up
-     * callbacks and send header packet. */
+static int dev_acquisition_start(const struct sr_dev_inst *sdi)
+{
+	/* TODO: configure hardware, reset acquisition state, set up
+	 * callbacks and send header packet. */
 
-    (void) sdi;
+	(void)sdi;
 
-    return SR_OK;
+	return SR_OK;
 }
 
-static int dev_acquisition_stop(struct sr_dev_inst *sdi) {
-    /* TODO: stop acquisition. */
+static int dev_acquisition_stop(struct sr_dev_inst *sdi)
+{
+	/* TODO: stop acquisition. */
 
-    (void) sdi;
+	(void)sdi;
 
 	return SR_OK;
 }

--- a/src/hardware/pslab/protocol.c
+++ b/src/hardware/pslab/protocol.c
@@ -20,22 +20,25 @@
 #include <config.h>
 #include "protocol.h"
 
-SR_PRIV int pslab_receive_data(int fd, int revents, void *cb_data)
-{
-	const struct sr_dev_inst *sdi;
-	struct dev_context *devc;
+SR_PRIV int pslab_receive_data(int fd, int revents, void *cb_data) {
+    const struct sr_dev_inst *sdi;
+    struct dev_context *devc;
 
-	(void)fd;
+    (void) fd;
 
-	if (!(sdi = cb_data))
-		return TRUE;
+    if (!(sdi = cb_data))
+        return TRUE;
 
-	if (!(devc = sdi->priv))
-		return TRUE;
+    if (!(devc = sdi->priv))
+        return TRUE;
 
-	if (revents == G_IO_IN) {
-		/* TODO */
-	}
+    if (revents == G_IO_IN) {
+        /* TODO */
+    }
 
-	return TRUE;
+    return TRUE;
+}
+
+SR_PRIV struct dev_context *pslab_dev_new() {
+
 }

--- a/src/hardware/pslab/protocol.c
+++ b/src/hardware/pslab/protocol.c
@@ -20,25 +20,22 @@
 #include <config.h>
 #include "protocol.h"
 
-SR_PRIV int pslab_receive_data(int fd, int revents, void *cb_data) {
-    const struct sr_dev_inst *sdi;
-    struct dev_context *devc;
+SR_PRIV int pslab_receive_data(int fd, int revents, void *cb_data)
+{
+	const struct sr_dev_inst *sdi;
+	struct dev_context *devc;
 
-    (void) fd;
+	(void)fd;
 
-    if (!(sdi = cb_data))
-        return TRUE;
+	if (!(sdi = cb_data))
+		return TRUE;
 
-    if (!(devc = sdi->priv))
-        return TRUE;
+	if (!(devc = sdi->priv))
+		return TRUE;
 
-    if (revents == G_IO_IN) {
-        /* TODO */
-    }
+	if (revents == G_IO_IN) {
+		/* TODO */
+	}
 
-    return TRUE;
-}
-
-SR_PRIV struct dev_context *pslab_dev_new() {
-
+	return TRUE;
 }

--- a/src/hardware/pslab/protocol.h
+++ b/src/hardware/pslab/protocol.h
@@ -26,10 +26,34 @@
 #include "libsigrok-internal.h"
 
 #define LOG_PREFIX "pslab"
+#define NUM_ANALOG_CHANNELS 8
 
 struct dev_context {
 };
 
+struct analog_channel {
+    const char *name;
+
+    int chosa;
+};
+
+struct channel_priv {
+
+    int samples_in_buffer;
+
+    int buffer_idx;
+
+    int chosa;
+
+    int gain;
+
+    int programmable_gain_amplifier;
+
+    int resolution;
+};
+
 SR_PRIV int pslab_receive_data(int fd, int revents, void *cb_data);
+
+SR_PRIV struct dev_context *pslab_dev_new();
 
 #endif

--- a/src/hardware/pslab/protocol.h
+++ b/src/hardware/pslab/protocol.h
@@ -32,24 +32,24 @@ struct dev_context {
 };
 
 struct analog_channel {
-    const char *name;
+	const char *name;
 
-    int chosa;
+	int chosa;
 };
 
 struct channel_priv {
 
-    int samples_in_buffer;
+	int samples_in_buffer;
 
-    int buffer_idx;
+	int buffer_idx;
 
-    int chosa;
+	int chosa;
 
-    int gain;
+	int gain;
 
-    int programmable_gain_amplifier;
+	int programmable_gain_amplifier;
 
-    int resolution;
+	int resolution;
 };
 
 SR_PRIV int pslab_receive_data(int fd, int revents, void *cb_data);


### PR DESCRIPTION
The code scans all ports for PSLab device and instantiates the device and its channels
Fixes #3



**How to test**
Use the following command on sigrok-cli to scan device
`./sigrok-cli --scan `